### PR TITLE
Remove data_files from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     },
     package_dir={"": "src"},
     install_requires=['pytest>=2.7.0'],
-    data_files = [("", ["LICENSE"])],
     author='Gabriel Reis',
     author_email='gabrielcnr@gmail.com',
     description='pytest plugin for test data directories and files',


### PR DESCRIPTION
This is not necessary because `setuptools-scm` already takes care of including the file in the source dist, plus this is causing the conda package to contain a `LICENSE` file in the root of the conda environment, which is conflicting with other packages.